### PR TITLE
Adding funcitonality that ommits Rstudio progress

### DIFF
--- a/.Rproj.user/CB429810/sources/prop/INDEX
+++ b/.Rproj.user/CB429810/sources/prop/INDEX
@@ -9,6 +9,7 @@
 ~%2FLibrary%2FMobile%20Documents%2Fcom~apple~CloudDocs%2Feight_schools_data_model.Rmd="303E3BD2"
 ~%2FLibrary%2FMobile%20Documents%2Fcom~apple~CloudDocs%2Feight_schools_equiv_models.Rmd="A930226B"
 ~%2FLibrary%2FMobile%20Documents%2Fcom~apple~CloudDocs%2Frjuliabugs_translation_overview.Rmd="9361413F"
+~%2Frjuliabug_test.R="ED636243"
 ~%2Frjuliabugs%2F.github%2Fworkflows%2FR-CMD-check.yaml="4B9598A6"
 ~%2Frjuliabugs%2F.github%2Fworkflows%2Fpkgdown.yaml="151CC288"
 ~%2Frjuliabugs%2F.gitignore="460D4755"

--- a/R/utils.R
+++ b/R/utils.R
@@ -45,7 +45,7 @@ julia_assign_int <- function(x, value) {
 #' \item{\code{"draws"}}{An object of class \code{draws_array} or similar from the \pkg{posterior} package.}
 #'
 #' @details
-#' The function assumes that \code{get_params_from_name()} and other referenced variables such as \code{params_to_save} and \code{n_chain} are available in the current environment.
+#' The function assumes that \code{get_params_from_name_raw()} and other referenced variables such as \code{params_to_save} and \code{n_chain} are available in the current environment.
 #'
 #' @importFrom posterior rvar as_draws
 #' @importFrom coda as.mcmc as.mcmc.list mcmc

--- a/man/get_params.Rd
+++ b/man/get_params.Rd
@@ -24,7 +24,7 @@ The posterior samples converted to the specified format. The return type depends
 This function extracts parameters from an object created by `rjuliabugs` and converts them to a specified posterior format.
 }
 \details{
-The function assumes that \code{get_params_from_name()} and other referenced variables such as \code{params_to_save} and \code{n_chain} are available in the current environment.
+The function assumes that \code{get_params_from_name_raw()} and other referenced variables such as \code{params_to_save} and \code{n_chain} are available in the current environment.
 }
 \examples{
 \dontrun{

--- a/man/juliaBUGS.Rd
+++ b/man/juliaBUGS.Rd
@@ -58,7 +58,13 @@ The default is \code{NULL}, which means no default initial values are used.}
 \item{\code{julia_model}}{Logical. If \code{TRUE}, assumes the model is already in Julia format used by the models under the \code{Turing.jl} appraoch, not a BUGS model. Default is \code{FALSE}.}
 }}
 
-\item{progress}{Logical. If \code{TRUE}, a progress bar will be displayed; if \code{FALSE}, it will not. The default is \code{TRUE}.}
+\item{progress}{Logical. If \code{TRUE}, a progress bar is displayed; if \code{FALSE},
+no progress bar is shown. The default is \code{TRUE}. However, when the function
+is run interactively inside an RStudio session, \code{progress} is automatically
+overridden to \code{FALSE}, which suppresses the progress output from
+\code{AbstractMCMC.sample}. For a complete progress bar display with \code{rjuliabugs},
+as the one showed when running Julia code,we recommend running the code from
+a terminal outside of RStudio.}
 
 \item{...}{Additional arguments passed to \code{setup_juliaBUGS()}.}
 }


### PR DESCRIPTION
Rstudio do not display a nice progress bar for using JuliaCall; This supress any AbstractMCMC.sample messages() or at least most of it.